### PR TITLE
Fixed crash caused by incorrect comparison of glyph keys in glyph cache

### DIFF
--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -35,7 +35,7 @@ LOCAL_CFLAGS += -Wall -Wno-unused-variable -Wno-sign-compare -Wno-write-strings 
 
 LOCAL_CFLAGS += -funwind-tables -Wl,--no-merge-exidx-entries
 
-LOCAL_CFLAGS += -g -O1 -fexceptions
+LOCAL_CFLAGS += -g -O1 -fexceptions -flto
 
 CRENGINE_SRC_FILES := \
     ../../crengine/src/cp_stats.cpp \
@@ -53,12 +53,17 @@ CRENGINE_SRC_FILES := \
     ../../crengine/src/epubfmt.cpp \
     ../../crengine/src/pdbfmt.cpp \
     ../../crengine/src/wordfmt.cpp \
+    ../../crengine/src/lvopc.cpp \
+    ../../crengine/src/docxfmt.cpp \
+    ../../crengine/src/fb3fmt.cpp \
     ../../crengine/src/lvstsheet.cpp \
     ../../crengine/src/txtselector.cpp \
     ../../crengine/src/crtest.cpp \
     ../../crengine/src/lvbmpbuf.cpp \
     ../../crengine/src/lvfnt.cpp \
     ../../crengine/src/hyphman.cpp \
+    ../../crengine/src/lvfont.cpp \
+    ../../crengine/src/lvembeddedfont.cpp \
     ../../crengine/src/lvfntman.cpp \
     ../../crengine/src/lvimg.cpp \
     ../../crengine/src/crskin.cpp \
@@ -70,6 +75,12 @@ CRENGINE_SRC_FILES := \
     ../../crengine/src/wolutil.cpp \
     ../../crengine/src/crconcurrent.cpp \
     ../../crengine/src/hist.cpp \
+    ../../crengine/src/private/lvfontglyphcache.cpp \
+    ../../crengine/src/private/lvfontboldtransform.cpp \
+    ../../crengine/src/private/lvfontcache.cpp \
+    ../../crengine/src/private/lvfontdef.cpp \
+    ../../crengine/src/private/lvfreetypeface.cpp \
+    ../../crengine/src/private/lvfreetypefontman.cpp \
     ../../crengine/fc-lang/fc-lang-cat.c
 #    ../../crengine/src/cri18n.cpp
 #    ../../crengine/src/crgui.cpp \
@@ -116,7 +127,7 @@ LOCAL_STATIC_LIBRARIES := \
     local_chmlib \
     local_antiword
 
-LOCAL_LDLIBS    := -lm -llog -lz -ldl
+LOCAL_LDLIBS    := -lm -llog -lz -ldl -flto
 # 
 #LOCAL_LDLIBS    += -Wl,-Map=cr3engine.map
 #-ljnigraphics

--- a/crengine/include/lvfont.h
+++ b/crengine/include/lvfont.h
@@ -35,7 +35,7 @@ enum font_antialiasing_t {
     font_aa_all
 };
 
-class LVFontGlyphCacheItem;
+struct LVFontGlyphCacheItem;
 
 /** \brief base class for fonts
 

--- a/crengine/src/private/lvfontglyphcache.cpp
+++ b/crengine/src/private/lvfontglyphcache.cpp
@@ -14,120 +14,38 @@
 
 #include "lvfontglyphcache.h"
 #include "../../include/crlocks.h"
+#include "lvhashtable.h"
+#define GLYPHCACHE_TABLE_SZ         256
 
-#if USE_GLYPHCACHE_HASHTABLE == 1
-inline lUInt32 getHash(GlyphCacheItemData data)
+class LVLocalGlyphCacheHashTableStorage : public LVLocalGlyphCacheStorage
 {
-    return getHash(*((lUInt32*)&data));
-}
+    LVHashTable<lUInt32, struct LVFontGlyphCacheItem*> hashTable;
+public:
+    LVLocalGlyphCacheHashTableStorage(LVFontGlobalGlyphCache *global_cache, int size) :
+        LVLocalGlyphCacheStorage(global_cache), hashTable(size) {
+    }
+    LVFontGlyphCacheItem* get(lUInt32 ch);
+    void put(LVFontGlyphCacheItem *item);
+    void remove(LVFontGlyphCacheItem *item);
+    void clear();
+};
 
-inline bool operator==(GlyphCacheItemData data1, GlyphCacheItemData data2)
+class LVLocalGlyphCacheListStorage : public LVLocalGlyphCacheStorage
 {
-    return (*((lUInt32*)&data1)) == (*((lUInt32*)&data2));
-}
-#endif
-
-void LVFontLocalGlyphCache::clear() {
-    FONT_LOCAL_GLYPH_CACHE_GUARD
-#if USE_GLYPHCACHE_HASHTABLE == 1
-    LVHashTable<GlyphCacheItemData, struct LVFontGlyphCacheItem*>::iterator it = hashTable.forwardIterator();
-    LVHashTable<GlyphCacheItemData, struct LVFontGlyphCacheItem*>::pair* pair;
-    while ((pair = it.next()))
-    {
-        global_cache->remove(pair->value);
-        LVFontGlyphCacheItem::freeItem(pair->value);
+    LVFontGlyphCacheItem* head;
+    LVFontGlyphCacheItem* tail;
+public:
+    LVLocalGlyphCacheListStorage(LVFontGlobalGlyphCache *global_cache) :
+        LVLocalGlyphCacheStorage(global_cache), head(), tail() {}
+    ~LVLocalGlyphCacheListStorage() {
+        clear();
     }
-    hashTable.clear();
-#else
-    while (head) {
-        LVFontGlyphCacheItem *ptr = head;
-        remove(ptr);
-        global_cache->remove(ptr);
-        LVFontGlyphCacheItem::freeItem(ptr);
-    }
-#endif
-}
+    LVFontGlyphCacheItem* get(lUInt32 ch);
+    void put(LVFontGlyphCacheItem *item);
+    void remove(LVFontGlyphCacheItem *item);
+    void clear();
+};
 
-LVFontGlyphCacheItem *LVFontLocalGlyphCache::get(lChar16 ch) {
-    FONT_LOCAL_GLYPH_CACHE_GUARD
-#if USE_GLYPHCACHE_HASHTABLE == 1
-    LVFontGlyphCacheItem *ptr = 0;
-    GlyphCacheItemData data;
-    data.ch = ch;
-    if (hashTable.get(data, ptr))
-        return ptr;
-#else
-    LVFontGlyphCacheItem *ptr = head;
-    for (; ptr; ptr = ptr->next_local) {
-        if (ptr->data.ch == ch) {
-            global_cache->refresh(ptr);
-            return ptr;
-        }
-    }
-#endif
-    return NULL;
-}
-
-#if USE_HARFBUZZ==1
-LVFontGlyphCacheItem*LVFontLocalGlyphCache::getByIndex(lUInt32 index)
-{
-    FONT_LOCAL_GLYPH_CACHE_GUARD
-#if USE_GLYPHCACHE_HASHTABLE == 1
-    LVFontGlyphCacheItem *ptr = 0;
-    GlyphCacheItemData data;
-    data.gindex = index;
-    if (hashTable.get(data, ptr))
-        return ptr;
-#else
-    LVFontGlyphCacheItem *ptr = head;
-    for (; ptr; ptr = ptr->next_local) {
-        if (ptr->data.gindex == index) {
-            global_cache->refresh(ptr);
-            return ptr;
-        }
-    }
-#endif
-    return NULL;
-}
-#endif
-
-void LVFontLocalGlyphCache::put(LVFontGlyphCacheItem *item) {
-    FONT_LOCAL_GLYPH_CACHE_GUARD
-    global_cache->put(item);
-#if USE_GLYPHCACHE_HASHTABLE == 1
-    hashTable.set(item->data, item);
-#else
-    item->next_local = head;
-    if (head)
-        head->prev_local = item;
-    if (!tail)
-        tail = item;
-    head = item;
-#endif
-}
-
-/// remove from list, but don't delete
-void LVFontLocalGlyphCache::remove(LVFontGlyphCacheItem *item) {
-    FONT_LOCAL_GLYPH_CACHE_GUARD
-#if USE_GLYPHCACHE_HASHTABLE == 1
-    hashTable.remove(item->data);
-#else
-    if (item == head)
-        head = item->next_local;
-    if (item == tail)
-        tail = item->prev_local;
-    if (!head || !tail)
-        return;
-    if (item->prev_local)
-        item->prev_local->next_local = item->next_local;
-    if (item->next_local)
-        item->next_local->prev_local = item->prev_local;
-    item->next_local = NULL;
-    item->prev_local = NULL;
-#endif
-}
-
-#if USE_GLYPHCACHE_HASHTABLE != 1
 void LVFontGlobalGlyphCache::refresh(LVFontGlyphCacheItem *item) {
     FONT_GLYPH_CACHE_GUARD
     if (tail != item) {
@@ -136,7 +54,6 @@ void LVFontGlobalGlyphCache::refresh(LVFontGlyphCacheItem *item) {
         putNoLock(item);
     }
 }
-#endif
 
 void LVFontGlobalGlyphCache::put(LVFontGlyphCacheItem *item) {
     FONT_GLYPH_CACHE_GUARD
@@ -195,32 +112,12 @@ void LVFontGlobalGlyphCache::clear() {
     }
 }
 
-LVFontGlyphCacheItem *LVFontGlyphCacheItem::newItem(LVFontLocalGlyphCache *local_cache, lChar16 ch, int w, int h) {
-    LVFontGlyphCacheItem *item = (LVFontGlyphCacheItem *) malloc(sizeof(LVFontGlyphCacheItem)
-                                                                 + (w * h - 1) * sizeof(lUInt8));
-    if (item) {
-        item->data.ch = ch;
-        item->bmp_width = (lUInt16) w;
-        item->bmp_height = (lUInt16) h;
-        item->origin_x = 0;
-        item->origin_y = 0;
-        item->advance = 0;
-        item->prev_global = NULL;
-        item->next_global = NULL;
-        item->prev_local = NULL;
-        item->next_local = NULL;
-        item->local_cache = local_cache;
-    }
-    return item;
-}
-
-#if USE_HARFBUZZ==1
 LVFontGlyphCacheItem *LVFontGlyphCacheItem::newItem(LVFontLocalGlyphCache* local_cache, lUInt32 glyph_index, int w, int h)
 {
     LVFontGlyphCacheItem *item = (LVFontGlyphCacheItem *) malloc(sizeof(LVFontGlyphCacheItem)
                                                                  + (w * h - 1) * sizeof(lUInt8));
     if (item) {
-        item->data.gindex = glyph_index;
+        item->data = glyph_index;
         item->bmp_width = (lUInt16) w;
         item->bmp_height = (lUInt16) h;
         item->origin_x = 0;
@@ -234,9 +131,126 @@ LVFontGlyphCacheItem *LVFontGlyphCacheItem::newItem(LVFontLocalGlyphCache* local
     }
     return item;
 }
-#endif // USE_HARFBUZZ==1
 
 void LVFontGlyphCacheItem::freeItem(LVFontGlyphCacheItem *item) {
     if (item)
         ::free(item);
 }
+
+LVFontGlyphCacheItem *LVLocalGlyphCacheHashTableStorage::get(lUInt32 ch)
+{
+    LVFontGlyphCacheItem *ptr = 0;
+    if (hashTable.get(ch, ptr))
+        m_global_cache->refresh(ptr);
+    return ptr;
+}
+
+void LVLocalGlyphCacheHashTableStorage::put(LVFontGlyphCacheItem *item)
+{
+    m_global_cache->put(item);
+    hashTable.set(item->data, item);
+}
+
+void LVLocalGlyphCacheHashTableStorage::remove(LVFontGlyphCacheItem *item)
+{
+    hashTable.remove(item->data);
+}
+
+void LVLocalGlyphCacheHashTableStorage::clear()
+{
+    FONT_LOCAL_GLYPH_CACHE_GUARD
+
+    LVHashTable<lUInt32, struct LVFontGlyphCacheItem*>::iterator it = hashTable.forwardIterator();
+    LVHashTable<lUInt32, struct LVFontGlyphCacheItem*>::pair* pair;
+    while( (pair = it.next()) ) {
+        m_global_cache->remove(pair->value);
+        LVFontGlyphCacheItem::freeItem(pair->value);
+    }
+    hashTable.clear();
+}
+
+LVFontGlyphCacheItem *LVLocalGlyphCacheListStorage::get(lUInt32 ch)
+{
+    LVFontGlyphCacheItem *ptr = head;
+    for (; ptr; ptr = ptr->next_local) {
+        if (ptr->data == ch) {
+            m_global_cache->refresh(ptr);
+            return ptr;
+        }
+    }
+    return NULL;
+}
+
+void LVLocalGlyphCacheListStorage::put(LVFontGlyphCacheItem *item)
+{
+    m_global_cache->put(item);
+    item->next_local = head;
+    if (head)
+        head->prev_local = item;
+    if (!tail)
+        tail = item;
+    head = item;
+}
+
+void LVLocalGlyphCacheListStorage::remove(LVFontGlyphCacheItem *item)
+{
+    if (item == head)
+        head = item->next_local;
+    if (item == tail)
+        tail = item->prev_local;
+    if (!head || !tail)
+        return;
+    if (item->prev_local)
+        item->prev_local->next_local = item->next_local;
+    if (item->next_local)
+        item->next_local->prev_local = item->prev_local;
+    item->next_local = NULL;
+    item->prev_local = NULL;
+}
+
+void LVLocalGlyphCacheListStorage::clear()
+{
+    while (head) {
+        LVFontGlyphCacheItem *ptr = head;
+        remove(ptr);
+        m_global_cache->remove(ptr);
+        LVFontGlyphCacheItem::freeItem(ptr);
+    }
+}
+void LVFontLocalGlyphCache::clear()
+{
+    FONT_LOCAL_GLYPH_CACHE_GUARD
+
+    m_storage->clear();
+}
+
+LVFontGlyphCacheItem *LVFontLocalGlyphCache::get(lUInt32 index)
+{
+    FONT_LOCAL_GLYPH_CACHE_GUARD
+    return m_storage->get(index);
+}
+
+void LVFontLocalGlyphCache::put(LVFontGlyphCacheItem *item)
+{
+    FONT_LOCAL_GLYPH_CACHE_GUARD
+    m_storage->put(item);
+}
+
+void LVFontLocalGlyphCache::remove(LVFontGlyphCacheItem *item)
+{
+    FONT_LOCAL_GLYPH_CACHE_GUARD
+    m_storage->remove(item);
+}
+
+#if USE_GLYPHCACHE_HASHTABLE == 1
+LVFontLocalGlyphCache::LVFontLocalGlyphCache(LVFontGlobalGlyphCache *globalCache)
+{
+    m_storage = new LVLocalGlyphCacheHashTableStorage(globalCache, GLYPHCACHE_TABLE_SZ);
+}
+#else
+LVFontLocalGlyphCache::LVFontLocalGlyphCache(LVFontGlobalGlyphCache *globalCache)
+{
+    m_storage = new LVLocalGlyphCacheListStorage(globalCache);
+}
+#endif
+

--- a/crengine/src/private/lvfreetypeface.cpp
+++ b/crengine/src/private/lvfreetypeface.cpp
@@ -1066,7 +1066,7 @@ LVFontGlyphCacheItem *LVFreeTypeFace::getGlyph(lUInt16 ch, lChar16 def_char) {
 
 LVFontGlyphCacheItem* LVFreeTypeFace::getGlyphByIndex(lUInt32 index) {
     //FONT_GUARD
-    LVFontGlyphCacheItem *item = _glyph_cache2.getByIndex(index);
+    LVFontGlyphCacheItem *item = _glyph_cache2.get(index);
     if (!item) {
         // glyph not found in cache, rendering...
         int rend_flags = FT_LOAD_RENDER | (!_drawMonochrome ? FT_LOAD_TARGET_NORMAL


### PR DESCRIPTION
A union GlyphCacheItemData was used as a key too lookup the glyphs in the cache. There is a problem with the way its values are compared, according to cpp reference:
> The union is only as big as necessary to hold its largest data member. The other data members are allocated in the same bytes as part of that largest member. The details of that allocation are implementation-defined, and i**t's undefined behavior to read from the member of the union that wasn't most recently written**. 

The == operator was implemented as:

`return (*((lUInt32*)&data1)) == (*((lUInt32*)&data2));`

The problem might occur when it is used with ch member set. On windows it caused crashes. Because of wrong comparisons, we attempted to remove already deleted item.

in addition to the fix I refactored the code a bit, just to avoid ifdefs scattered across the code. Feel free to ignore this part.